### PR TITLE
Corrected master hostname

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -18,7 +18,7 @@
 
 # Define filebucket 'main':
 filebucket { 'main':
-  server => 'puppetfactory.puppetlabs.vm',
+  server => 'master.puppetlabs.vm',
   path   => false,
 }
 


### PR DESCRIPTION
We accidentally left an old name in the site.pp manifest. This patch should correct it!

Many apologies.
